### PR TITLE
Add custom Kit QuerySet manager

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -8,10 +8,13 @@ from django.db import models
 import django.contrib.auth.models
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import PermissionsMixin
+from django.core import exceptions
 import random
+
 
 class User(AbstractUser):
     pass
+
 
 def _generate_gravatar_alternative():
     """
@@ -27,9 +30,31 @@ def _generate_gravatar_alternative():
 
     return ''.join(random.choice('abcdefghijklmnopqrstuvwxyz0123456789') for i in range(RANDOM_STRING_LENGTH))
 
+
 class PersonUser(User):
     use_gravatar = models.BooleanField(default = True)
     gravatar_alternative = models.TextField(max_length = 255, default = _generate_gravatar_alternative)
+
+
+class KitQuerySet(models.QuerySet):
+    """
+    AstroPlant Kit QuerySet class
+
+    See:
+    https://docs.djangoproject.com/en/1.11/topics/db/managers/#creating-a-manager-with-queryset-methods
+    """
+    def owned_by(self, user):
+        return self.filter(users=user)
+
+    def shown_on_map(self):
+        return self.filter(privacy_show_on_map=True)
+
+    def safe_get(self, kit_id):
+        try:
+            kit = self.get(pk=kit_id)
+        except Kit.DoesNotExist:
+            kit = None
+        return kit
 
 
 class Kit(User):
@@ -52,6 +77,8 @@ class Kit(User):
         through='KitMembership',
         through_fields=('kit', 'user'),
     )
+
+    kits = KitQuerySet.as_manager()
 
     class Meta:
         verbose_name = 'Kit'
@@ -142,6 +169,7 @@ class Kit(User):
 
         return {'serial': self.username, 'name': self.name, 'modules': modules, 'peripherals': peripherals}
 
+    @staticmethod
     def generate_password():
         import random
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,7 +52,7 @@ class KitQuerySet(models.QuerySet):
     def safe_get(self, kit_id):
         try:
             kit = self.get(pk=kit_id)
-        except Kit.DoesNotExist:
+        except exceptions.ObjectDoesNotExist:
             kit = None
         return kit
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -29,7 +29,7 @@ class KitViewSet(viewsets.GenericViewSet,
         if isinstance(user, models.Kit):
             return models.Kit.objects.filter(pk=user.pk)
         else:
-            return models.Kit.objects.filter(users=user.pk)
+            return models.Kit.kits.owned_by(user=user.pk)
 
     serializer_class = serializers.HyperlinkedKitSerializer
 
@@ -37,9 +37,8 @@ class KitViewSet(viewsets.GenericViewSet,
     def config(self, request, pk=None):
         qs = self.get_queryset()
         kit_query = qs.filter(pk=pk)
-        if not kit_query:
+        if not kit_query.exists():
             return response.Response({"detail": "Not found."}, status=404)
-
         kit = kit_query.get()
         return response.Response(kit.generate_config())
 
@@ -62,7 +61,7 @@ class KitConfigViewSet(viewsets.ViewSet):
         if isinstance(user, models.Kit):
             return models.Kit.objects.filter(pk=user.pk)
         else:
-            return models.Kit.objects.filter(users=user.pk)
+            return models.Kit.kits.owned_by(user=user.pk)
 
     def list(self, request, format=None):
         qs = self.get_queryset()
@@ -89,7 +88,7 @@ class ExperimentViewSet(viewsets.GenericViewSet,
         if isinstance(user, models.Kit):
             return models.Experiment.objects.filter(kit=user.pk)
         else:
-            kits = models.Kit.objects.filter(users=user.pk)
+            kits = models.Kit.kits.owned_by(user.pk)
             return models.Experiment.objects.filter(kit__in=kits)
 
     serializer_class = serializers.HyperlinkedExperimentSerializer
@@ -155,7 +154,7 @@ class PeripheralViewSet(viewsets.GenericViewSet,
         if isinstance(user, models.Kit):
             return models.Peripheral.objects.filter(kit=user.pk)
         else:
-            kits = models.Kit.objects.filter(users=user.pk)
+            kits = models.Kit.kits.owned_by(user.pk)
             return models.Peripheral.objects.filter(kit__in=kits)
 
     serializer_class = serializers.HyperlinkedPeripheralSerializer
@@ -185,7 +184,7 @@ class MeasurementViewSet(viewsets.GenericViewSet,
         if isinstance(user, models.Kit):
             return models.Measurement.objects.filter(kit=user.pk)
         else:
-            kits = models.Kit.objects.filter(users=user.pk)
+            kits = models.Kit.kits.owned_by(user.pk)
             return models.Measurement.objects.filter(kit__in=kits)
 
     serializer_class = serializers.HyperlinkedMeasurementSerializer

--- a/website/views.py
+++ b/website/views.py
@@ -15,29 +15,30 @@ from dal import autocomplete
 import backend.models
 import website.forms
 
+
 def index(request):
     context = {}
     return render(request, 'website/index.html', context)
-    
+
+
 def map(request):
     # Note that we don't use GeoDjango; it requires a heavy gdal setup. All
     # we need is a simple map, and a full gdal setup would just make deployment
     # more difficult
-    context = {'kits': backend.models.Kit.objects.filter(privacy_show_on_map=True)}
+    context = {'kits': backend.models.Kit.kits.shown_on_map()}
 
     return render(request,'website/map.html', context)
-       
+
+
 @decorators.login_required
 def dashboard(request):
-    context = {'kits': backend.models.Kit.objects.filter(users=request.user)}
+    context = {'kits': backend.models.Kit.kits.owned_by(user=request.user)}
 
     return render(request,'website/dashboard.html', context)
 
+
 def kit(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     context = {'kit': kit,
                'can_view_kit_dashboard': request.user.has_perm('backend.view_kit_dashboard', kit),
@@ -45,11 +46,9 @@ def kit(request, kit_id):
 
     return render(request, 'website/kit.html', context)
 
+
 def kit_download(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     context = {'kit': kit,
                'can_view_kit_dashboard': request.user.has_perm('backend.view_kit_dashboard', kit),
@@ -116,10 +115,7 @@ def kit_download(request, kit_id):
     
 @decorators.login_required
 def kit_configure_profile(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -147,10 +143,7 @@ def kit_configure_profile(request, kit_id):
 
 @decorators.login_required
 def kit_configure_members(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -191,10 +184,7 @@ def kit_configure_members(request, kit_id):
 
 @decorators.login_required
 def kit_configure_location(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -218,10 +208,7 @@ def kit_configure_location(request, kit_id):
 
 @decorators.login_required
 def kit_configure_peripherals(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -263,10 +250,7 @@ def kit_configure_peripherals(request, kit_id):
 
 @decorators.login_required
 def kit_configure_peripherals_add(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -293,10 +277,7 @@ def kit_configure_peripherals_add(request, kit_id):
 
 @decorators.login_required
 def kit_configure_peripherals_add_step2(request, kit_id, peripheral_definition_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -365,10 +346,7 @@ def kit_configure_peripherals_add_step2(request, kit_id, peripheral_definition_i
 
 @decorators.login_required
 def kit_configure_access(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')
@@ -387,10 +365,7 @@ def kit_configure_access(request, kit_id):
 
 @decorators.login_required
 def kit_configure_danger_zone(request, kit_id):
-    try:
-        kit = backend.models.Kit.objects.get(pk=kit_id)
-    except exceptions.ObjectDoesNotExist:
-        kit = None
+    kit = backend.models.Kit.kits.safe_get(kit_id)
 
     if not kit or not request.user.has_perm('backend.configure_kit', kit):
         return render(request, 'website/kit_configure_not_found.html')


### PR DESCRIPTION
This allows for repeated filters / code-blocks to be abstracted and managed in a single space.

The reason I didn't replace the default 'objects' Manager is because Kit is a special User-type model which has additional functionality inserted into the default manager by Django.

These custom QuerySets can also be implemented for the Measurement, Experiment and other models if relevant.